### PR TITLE
Multiply `withoutBaseFee` before dividing it to maintain precision.

### DIFF
--- a/contracts/utils/FeeDistributor.sol
+++ b/contracts/utils/FeeDistributor.sol
@@ -39,7 +39,7 @@ contract FeeDistributor is IFeeDistributor {
     /// @notice Calculate the fee from the full amount + fee
     function calculateFee(address token, uint256 amount) internal view returns (uint256 fee) {
         uint256 baseFeeAmount = baseFee[token];
-        uint256 withoutBaseFee = amount - baseFeeAmount;
-        return amount - ((withoutBaseFee / (10000 + feePercentBps)) * 10000);
+        uint256 withoutBaseFee = (amount - baseFeeAmount) * 10000;
+        return amount - (withoutBaseFee / (10000 + feePercentBps));
     }
 }


### PR DESCRIPTION
## Description
This PR flips the order of arithmetic operations when computing the `Fee` in the `FeeDistributor` contract. The reason behind this is multiplying an integer before dividing it results in higher precision of the resulting value.

This wasn't a big issue because the rounding error was minimal and if anything, someone just has to pay a little less fee in the end.