### PR TITLE
Add `recipient` address to error message instead of the `feeCollector`.

### DIFF
--- a/contracts/TokenBuyer.sol
+++ b/contracts/TokenBuyer.sol
@@ -57,7 +57,7 @@ contract TokenBuyer is ITokenBuyer, FeeDistributor, Signatures {
     }
 
     function sweep(address token, address payable recipient, uint256 amount) external onlyFeeCollector {
-        if (!IERC20(token).transfer(recipient, amount)) revert TransferFailed(address(this), feeCollector);
+        if (!IERC20(token).transfer(recipient, amount)) revert TransferFailed(address(this), recipient);
         emit TokensSweeped(token, recipient, amount);
     }
 }


### PR DESCRIPTION
## Description
Just a small nitpick: The error message should contain the recipient's address (to whom we are attempting to transfer tokens) instead of the `feeCollector`'s address (who should be the function caller).